### PR TITLE
Add availability tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ streamlit-authenticator
 pandas
 pyyaml
 openpyxl
+pytest
+

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+
+def is_available(availability_lookup, ta, slot):
+    try:
+        value = availability_lookup.loc[ta, slot]
+        return str(value).strip() in ["\u2713", "True", "TRUE", "true"]
+    except KeyError:
+        return False
+    except Exception:
+        return False
+
+
+def mock_lookup():
+    df = pd.DataFrame({
+        "TA Name": ["Alice", "Bob"],
+        "Monday P1": ["\u2713", True],
+        "Monday P2": ["", None],
+    })
+    return df.set_index("TA Name").replace("\u2713", True).fillna(False)
+
+
+def test_true_values():
+    lookup = mock_lookup()
+    assert is_available(lookup, "Alice", "Monday P1") is True
+    assert is_available(lookup, "Bob", "Monday P1") is True
+
+
+def test_blank_or_missing_values():
+    lookup = mock_lookup()
+    assert is_available(lookup, "Alice", "Monday P2") is False
+    assert is_available(lookup, "Bob", "Nonexistent") is False


### PR DESCRIPTION
## Summary
- add pytest to requirements
- create `tests/test_availability.py` with mocked availability lookup tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684da07035a48320a63a3cef60b4d242