### PR TITLE
Fix username capture

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -33,7 +33,7 @@ def setup_authenticator():
 
 # --- Call it here ---
 authenticator = setup_authenticator()
-name, authentication_status, username = authenticator.login("Login", "main")
+name, authentication_status, _ = authenticator.login("Login", "main")
 
 
 


### PR DESCRIPTION
## Summary
- ignore username when logging in with streamlit-authenticator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da74210848320b3bd36ece2a022df