### PR TITLE
Improve authenticator credential handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -55,6 +55,27 @@ Each sheet should follow the structure outlined below:
 
 ---
 
+Authentication Setup:
+---------------------
+Provide your own login details through a `.streamlit/secrets.toml` file or environment variables.
+
+Example `secrets.toml`:
+```
+[auth]
+usernames = ["user1", "user2"]
+names = ["User One", "User Two"]
+hashed_passwords = ["<hash1>", "<hash2>"]
+```
+
+Environment variable alternative:
+- `AUTH_USERNAMES="user1,user2"`
+- `AUTH_NAMES="User One,User Two"`
+- `AUTH_HASHED_PASSWORDS="<hash1>,<hash2>"`
+
+You can generate password hashes using `streamlit_authenticator.Hasher` in a Python shell.
+
+---
+
 Using the App:
 --------------
 1. Upload the formatted Excel file when prompted.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,18 +8,31 @@ st.set_page_config(layout="wide")
 
 
 def setup_authenticator():
-    usernames = ["hannah", "wendy"]
-    names = ["Hannah", "Wendy"]
-    hashed_passwords = [
-        "$2b$12$rLVuAJgX6cHIdJ1bl4DP3eALX0rOv.lzRGMh1ukM6oP.TZStBJHcW",  # hannah
-        "$2b$12$Zx9lY2bKf7kqjTR5IduUw.OTqT6Ybvv8y7ggcZk0OeWUM/OE/Ig2m"   # wendy
-    ]
+    if "auth" in st.secrets:
+        creds = st.secrets["auth"]
+        usernames = creds.get("usernames", [])
+        names = creds.get("names", [])
+        hashed_passwords = creds.get("hashed_passwords", [])
+    else:
+        usernames = os.getenv("AUTH_USERNAMES", "").split(",") if os.getenv("AUTH_USERNAMES") else []
+        names = os.getenv("AUTH_NAMES", "").split(",") if os.getenv("AUTH_NAMES") else []
+        hashed_passwords = os.getenv("AUTH_HASHED_PASSWORDS", "").split(",") if os.getenv("AUTH_HASHED_PASSWORDS") else []
+
+    if not (usernames and names and hashed_passwords):
+        usernames = ["hannah", "wendy"]
+        names = ["Hannah", "Wendy"]
+        hashed_passwords = [
+            "$2b$12$rLVuAJgX6cHIdJ1bl4DP3eALX0rOv.lzRGMh1ukM6oP.TZStBJHcW",
+            "$2b$12$Zx9lY2bKf7kqjTR5IduUw.OTqT6Ybvv8y7ggcZk0OeWUM/OE/Ig2m",
+        ]
+        st.warning("Using default demo credentials. Set your own via secrets or environment variables.")
 
     credentials = {
         usernames[i]: {
             "name": names[i],
-            "password": hashed_passwords[i]
-        } for i in range(len(usernames))
+            "password": hashed_passwords[i],
+        }
+        for i in range(min(len(usernames), len(names), len(hashed_passwords)))
     }
 
     authenticator = stauth.Authenticate(


### PR DESCRIPTION
## Summary
- read login details from `st.secrets` or environment variables in `setup_authenticator`
- document how to configure authentication

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684da73966b88320861ff7a372340b79