### PR TITLE
Fix login session state fallback

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -74,8 +74,9 @@ authenticator = setup_authenticator()
 # installed, so guard against that before unpacking.
 login_data = perform_login(authenticator)
 if login_data is None:
-    name = None
-    authentication_status = None
+    # Fallback to session state values when perform_login returns None
+    name = st.session_state.get("name")
+    authentication_status = st.session_state.get("authentication_status")
 else:
     try:
         name, authentication_status, _ = login_data


### PR DESCRIPTION
## Summary
- handle when `perform_login()` returns `None` by using `st.session_state`

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684dbd3276848320a3ff54786513f6d2