### PR TITLE
Add admin password change and fix access

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -74,6 +74,15 @@ Environment variable alternative:
 
 You can generate password hashes using `streamlit_authenticator.Hasher` in a Python shell.
 
+Admin Workflow:
+---------------
+When logged in as a username listed in `ADMIN_USERS` (default `admin`), a sidebar
+option **Admin** becomes available. On this page you can add, delete, or change
+passwords for users. Entering a username, display name and password stores the
+credentials in `user_credentials.yaml` with the password securely hashed. You can
+update a password by selecting a user in the **Change Password** form. Restart the
+app after making changes for new accounts to become active.
+
 ---
 
 Using the App:


### PR DESCRIPTION
## Summary
- fix admin access check to use username
- add change-password form in Admin page
- document password change workflow

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684dc666bbb8832082e123dd8c2bd6bd