### PR TITLE
Fix admin access check

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -77,17 +77,11 @@ You can generate password hashes using `streamlit_authenticator.Hasher` in a Pyt
 Admin Workflow:
 ---------------
 When logged in as a username listed in `ADMIN_USERS` (default `admin`), a sidebar
-
 option **Admin** becomes available. On this page you can add, delete, or change
 passwords for users. Entering a username, display name and password stores the
 credentials in `user_credentials.yaml` with the password securely hashed. You can
 update a password by selecting a user in the **Change Password** form. Restart the
 app after making changes for new accounts to become active.
-
-option **Admin** becomes available. On this page you can add or delete users.
-Entering a username, display name and password stores the credentials in
-`user_credentials.yaml` with the password securely hashed. Restart the app after
-making changes for new accounts to become active.
 
 
 ---

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -195,10 +195,7 @@ else:
 
     pages = ["Home"]
 
-    if username and username in ADMIN_USERS:
-
-    if name in ADMIN_USERS:
-
+    if (username and username in ADMIN_USERS) or (name in ADMIN_USERS):
         pages.append("Admin")
     choice = st.sidebar.radio("Navigation", pages)
     if choice == "Admin":


### PR DESCRIPTION
## Summary
- fix indentation for admin check in `streamlit_app.py`
- remove duplicate paragraph in README

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684dcb5952c48320943b3cfd8a80ea68