### PR TITLE
Handle duplicate TA names in availability sheet

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -346,16 +346,22 @@ if uploaded_file:
         "TA Name"
     ].unique()
     if len(duplicates) > 0:
-        st.error(
+        st.warning(
             "Duplicate TA names found in Availability sheet: "
             f"{', '.join(sorted(map(str, duplicates)))}. "
-            "Please ensure each TA appears only once."
+            "Combining entries into one."
         )
-        st.stop()
+        availability_df = (
+            availability_df.replace("\u2713", True)
+            .fillna(False)
+            .groupby("TA Name")
+            .any()
+            .reset_index()
+        )
+    else:
+        availability_df = availability_df.replace("\u2713", True).fillna(False)
 
-    availability_lookup = (
-        availability_df.set_index("TA Name").replace("\u2713", True).fillna(False)
-    )
+    availability_lookup = availability_df.set_index("TA Name")
     ta_assignment_count = defaultdict(int)
 
     def is_available(ta, slot):


### PR DESCRIPTION
## Summary
- allow duplicate TA names by merging availability rows
- warn the user and combine duplicate entries automatically

## Testing
- `python3 -m py_compile streamlit_app.py`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcd8f8d24832083d2d324c64f8e88