### PR TITLE
Add downloadable Excel timetable grids

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -455,3 +455,42 @@ if uploaded_file:
     )
     ta_summary.index.name = "TA Name"
     st.dataframe(ta_summary.reset_index())
+
+    def build_timetable_workbook(df: pd.DataFrame) -> bytes:
+        """Return an Excel workbook with a sheet for each TA in a grid format."""
+        from io import BytesIO
+
+        output = BytesIO()
+        day_order = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+        unique_days = list(df["Day"].dropna().unique())
+        days = [d for d in day_order if d in unique_days] + [
+            d for d in unique_days if d not in day_order
+        ]
+        periods = sorted(df["Period"].dropna().unique())
+        with pd.ExcelWriter(output, engine="openpyxl") as writer:
+            for ta in sorted(df["Assigned TA"].dropna().unique()):
+                if str(ta).startswith("\u26A0"):
+                    continue
+                ta_df = df[df["Assigned TA"] == ta].copy()
+                if ta_df.empty:
+                    continue
+                ta_df["Info"] = (
+                    ta_df["Year Group"].astype(str) + " - " + ta_df["Subject"].astype(str)
+                )
+                pivot = ta_df.pivot(index="Period", columns="Day", values="Info")
+                pivot = pivot.reindex(index=periods, columns=days)
+                pivot.index.name = ""
+                pivot.to_excel(writer, sheet_name=str(ta), startrow=1)
+                ws = writer.sheets[str(ta)]
+                ws.cell(row=1, column=1, value=str(ta))
+        output.seek(0)
+        return output.getvalue()
+
+    timetable_excel = build_timetable_workbook(timetable_df)
+    st.subheader("Download Timetable Grids")
+    st.download_button(
+        "Download Timetable Excel",
+        data=timetable_excel,
+        file_name="TA_Timetables.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )


### PR DESCRIPTION
## Summary
- create TA timetable workbook with day/period grid
- add download button for Excel timetable grids
- orient timetable grid with periods as rows
- order days Monday through Friday

## Testing
- `python -m py_compile streamlit_app.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684dd0fee4f08320ae9cadffbdfaf94e