### PR TITLE
Fix TA timetable pivot orientation

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -468,8 +468,6 @@ if uploaded_file:
             d for d in unique_days if d not in day_order
         ]
 
-        days = sorted(df["Day"].dropna().unique())
-
         periods = sorted(df["Period"].dropna().unique())
         with pd.ExcelWriter(output, engine="openpyxl") as writer:
             for ta in sorted(df["Assigned TA"].dropna().unique()):
@@ -481,9 +479,6 @@ if uploaded_file:
                 ta_df["Info"] = (
                     ta_df["Year Group"].astype(str) + " - " + ta_df["Subject"].astype(str)
                 )
-
-                pivot = ta_df.pivot(index="Period", columns="Day", values="Info")
-                pivot = pivot.reindex(index=periods, columns=days)
 
                 pivot = ta_df.pivot(index="Day", columns="Period", values="Info")
                 pivot = pivot.reindex(index=days, columns=periods)


### PR DESCRIPTION
## Summary
- fix pivot orientation in `build_timetable_workbook`
- keep days in calendar order when creating TA timetable sheets

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684dd57f36508320961df731c5d63c12